### PR TITLE
feat: 결제 완료된 티켓 리스트를 가져오는 메소드 추가 (#228)

### DIFF
--- a/SRT/reservation.py
+++ b/SRT/reservation.py
@@ -65,6 +65,7 @@ class SRTReservation:
         self.payment_date = pay["iseLmtDt"]
         self.payment_time = pay["iseLmtTm"]
 
+        self.paid = pay["stlFlg"] == "Y"  # 결제 여부
         self._tickets = tickets
 
     def __str__(self):
@@ -79,8 +80,7 @@ class SRTReservation:
             "{month}월 {day}일, "
             "{dep}~{arr}"
             "({dep_hour}:{dep_min}~{arr_hour}:{arr_min}) "
-            "{cost}원({seats}석), "
-            "구입기한 {pay_month}월 {pay_day}일 {pay_hour}:{pay_min}"
+            "{cost}원({seats}석)"
         ).format(
             name=self.train_name,
             month=self.dep_date[4:6],
@@ -93,12 +93,14 @@ class SRTReservation:
             arr_min=self.arr_time[2:4],
             cost=self.total_cost,
             seats=self.seat_count,
-            pay_month=self.payment_date[4:6],
-            pay_day=self.payment_date[6:8],
-            pay_hour=self.payment_time[0:2],
-            pay_min=self.payment_time[2:4],
         )
-
+        if not self.paid:
+            d += (", 구입기한 {pay_month}월 {pay_day}일 {pay_hour}:{pay_min}").format(
+                pay_month=self.payment_date[4:6],
+                pay_day=self.payment_date[6:8],
+                pay_hour=self.payment_time[0:2],
+                pay_min=self.payment_time[2:4],
+            )
         return d
 
     @property

--- a/SRT/srt.py
+++ b/SRT/srt.py
@@ -358,8 +358,11 @@ class SRT:
         else:
             SRTError("Ticket not found: check reservation status")
 
-    def get_reservations(self):
+    def get_reservations(self, paid_only: bool = False):
         """전체 예약 정보를 얻습니다.
+
+        Args:
+            paid_only (bool): 결제된 예약 내역만 가져올지 여부
 
         Returns:
             list[:class:`SRTReservation`]: 예약 리스트
@@ -382,6 +385,8 @@ class SRT:
         pay_data = parser.get_all()["payListMap"]
         reservations = []
         for train, pay in zip(train_data, pay_data):
+            if paid_only and pay["stlFlg"] == "N":  # paid_only가 참이면 결제된 예약내역만 보여줌
+                continue
             ticket = self.ticket_info(train["pnrNo"])
             reservation = SRTReservation(train, pay, ticket)
             reservations.append(reservation)

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -18,6 +18,7 @@ export SRT_PASSWORD=<YOUR_SRT_PASSWORD>
 # set SRT_PASSWORD=<YOUR_SRT_PASSWORD>
 
 pip install -r requirements/test.txt
+pip install -r requirements.txt
 
 black SRT
 pytest SRT -v -x


### PR DESCRIPTION
# Summary
  - 결제 완료된 티켓 리스트만 가져올 수 있게 API에 파라미터 추가

# What's Changed
- 기존 `get_reservations` 메소드는 결제 미완료/완료를 포함하여 모든 예약내역 리스트를 가져왔습니다. 하지만, 결제 완료된 티켓 정보와 미완료된 티켓 정보를 분리해서 보고 싶은 경우가 있습니다. 따라서 다음과 같이 변경했습니다.
  - 예약내역을 결제하였는지 확인하기 위한 `SRTReservation`에 `paid` 속성 추가
  - 결제 완료된 예약 내역에 대해서 `__repr__`과 `__str__` 다르게 보이게끔 `dump` 수정
  - `get_reservations` 메소드에서 결제 완료된 예약 내역만을 확인할 수 있는 파라미터 `paid_only` 추가
- `contribution.md` 수정

# How to Test
- `pytest SRT -v -x`
- 시나리오 테스트
```python
from SRT import SRT, SeatType
session = SRT('your-id', 'your-password')
trains = session.search_train('수서', '동탄', '20230425', '000000')
session.reserve(trains[0], special_seat=SeatType.GENERAL_FIRST)
reservations = session.get_reservations()
# ---> 해당 예약 내역 결제 진행--->
paid_reservations= session.get_reservations(paid_only=True)
```